### PR TITLE
Current version of suckless.vim does not respect the order of splitting like vim does

### DIFF
--- a/plugin/suckless.vim
+++ b/plugin/suckless.vim
@@ -361,6 +361,7 @@ endfunction "}}}
 
 function! CreateWindow(direction, ...) "{{{
   execute 'wincmd '.a:direction
+  enew
   if t:windowMode == 's'
     wincmd _
   endif

--- a/plugin/suckless.vim
+++ b/plugin/suckless.vim
@@ -360,14 +360,11 @@ function! ResizeWindow(direction, ...) "{{{
 endfunction "}}}
 
 function! CreateWindow(direction, ...) "{{{
-  wincmd n
+  execute 'wincmd '.a:direction
   if t:windowMode == 's'
     wincmd _
   endif
-  if (a:direction == 'v')
-    call MoveWindow('l')
-    stopinsert
-  endif
+  stopinsert
 endfunction "}}}
 
 function! CollapseWindow(...) "{{{
@@ -502,7 +499,7 @@ function! s:map(shortcut, action)
       if len(r_shortcut) == len(r_action)
         for i in range(len(r_shortcut))
           let action   = substitute(a:action,   regex, r_action[i],   '')
-          let shortcut = substitute(a:shortcut, regex, 
+          let shortcut = substitute(a:shortcut, regex,
                 \ escape(r_shortcut[i], '~&*'), '')
           call add(mappings, [ shortcut, action ])
         endfor


### PR DESCRIPTION
Ok, no one have asked me, but here we go.

The order of split commands in vim matters:
`split | vsplit` will cause the following scheme:
```
+--+--+
|  |  |
+--+--+
|     |
+-----+
```

while `vsplit | split` will create the following splitting:
```
+--+--+
|  |  |
+--+  +
|  |  |
+-----+
```

When suckless.vim is used it creates the second type scheme regardless
of the order.

In this merge I've replaced 'wincmd n' with 'wincmd a:direction' which
fixes the issue.