### PR TITLE
fix moving terminal window

### DIFF
--- a/plugin/suckless.vim
+++ b/plugin/suckless.vim
@@ -124,7 +124,7 @@ function! s:MoveToTab(viewnr, copy) "{{{
 
   " remove current window if 'copy' isn't set
   if a:copy == 0
-    wincmd c
+    close!
   endif
 
   " get a window in the requested Tab


### PR DESCRIPTION
close! hides the window if it is modified. (terminal windows count as modified)
this avoids the `E948: Job still running (add ! to end the job)` message.